### PR TITLE
docs: add missing build step to installation/usage sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Install dependencies:
 pnpm install
 ```
 
+```bash
+pnpm build
+```
+
 Add the environment variable `PRIVATE_KEY` to get a keypair by following the [Mysten Labs SDK guide](https://sdk.mystenlabs.com/typescript/cryptography/keypairs#deriving-a-keypair-from-a-bech32-encoded-secret-key)
 
 ## Usage


### PR DESCRIPTION
If one follows the README he or she will run `pnpm start`, this command expects transpiled `dist/indext.js`.

add instruction to run `pnpm build` before `pnpm start`